### PR TITLE
Add frontend and backend CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,33 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.lock
+          pip install flake8 pytest
+      - name: Lint
+        uses: py-actions/flake8@v2
+        with:
+          path: backend/app
+      - name: Test
+        run: |
+          pytest backend || if [ $? -eq 5 ]; then echo "No tests found."; else exit $?; fi

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,36 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+      - '.github/workflows/frontend.yml'
+  pull_request:
+    paths:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm install eslint --no-save
+      - run: npm run build
+      - run: npx eslint . --ext .ts,.tsx
+      - run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- add CI workflow for TypeScript build and lint
- add CI workflow for Python backend

## Testing
- `npm ci`
- `npm run build` *(fails: Could not resolve "../schemas/playbookSchema")*

------
https://chatgpt.com/codex/tasks/task_b_688747f442708330827c066d5393791d