### PR TITLE
Switch to GEMINI_API_KEY env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Create a `.env.local` file in the root directory:
 ```env
 # Required for AI features
 GEMINI_API_KEY=your_gemini_api_key_here
+# The application looks for this variable specifically
+# Older `API_KEY` references have been removed
 
 # Optional: Backend configuration
 BACKEND_URL=http://localhost:8000

--- a/services/acquisitionService.ts
+++ b/services/acquisitionService.ts
@@ -4,10 +4,10 @@ import { taskQueueService } from './taskQueueService';
 import type { AcquisitionProgress, AcquisitionStep, AcquiredBookData, BookDimensions } from '../types';
 import { acquiredBookDataSchema } from "../schemas/acquisitionSchema";
 
-if (!process.env.API_KEY) {
-    throw new Error("API_KEY environment variable not set");
+if (!process.env.GEMINI_API_KEY) {
+    throw new Error("GEMINI_API_KEY environment variable not set");
 }
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
 
 const ACQUISITION_PLAYBOOK: Omit<AcquisitionStep, 'status' | 'result'>[] = [
     { name: 'Simulated OCR & Dimension Extraction', agentId: 'agent-az86' },

--- a/services/chatService.ts
+++ b/services/chatService.ts
@@ -8,12 +8,12 @@ class ChatService {
     private chatHistories: Map<string, ChatMessage[]> = new Map();
 
     constructor() {
-        if (!process.env.API_KEY) {
-            console.error("API_KEY environment variable not set for ChatService.");
-            this.ai = null; 
+        if (!process.env.GEMINI_API_KEY) {
+            console.error("GEMINI_API_KEY environment variable not set for ChatService.");
+            this.ai = null;
             return;
         }
-        this.ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        this.ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
     }
 
     private async initializeChat(agentId: string): Promise<Chat | null> {
@@ -44,7 +44,7 @@ class ChatService {
 
     public async *sendMessageStream(agentId: string, message: string): AsyncGenerator<string, void, unknown> {
         if (!this.ai) {
-            yield "Error: Chat service is not initialized. Please configure your API_KEY.";
+            yield "Error: Chat service is not initialized. Please configure your GEMINI_API_KEY.";
             return;
         }
         

--- a/services/geminiClient.ts
+++ b/services/geminiClient.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI, GenerateContentResponse, Type, GenerateContentParameters } from "@google/genai";
 import { RpgBookAnalysis } from "../types";
 
-const apiKey = process.env.API_KEY ?? process.env.GEMINI_API_KEY;
+const apiKey = process.env.GEMINI_API_KEY;
 
 // Initialize AI client only if API key is available
 let ai: GoogleGenAI | null = null;
@@ -9,7 +9,7 @@ let ai: GoogleGenAI | null = null;
 if (apiKey) {
   ai = new GoogleGenAI({ apiKey });
 } else {
-  console.warn("API_KEY or GEMINI_API_KEY environment variable not set. Some features may not work.");
+  console.warn("GEMINI_API_KEY environment variable not set. Some features may not work.");
 }
 
 // --- Request Queue Implementation ---

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- rely on GEMINI_API_KEY everywhere
- simplify vite.config
- clarify README environment variable section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688755f20b5083308a18cf1bdbea5419