### PR TITLE
Add ArkType schemas for Loom service

### DIFF
--- a/schemas/acquisitionSchema.ts
+++ b/schemas/acquisitionSchema.ts
@@ -1,0 +1,20 @@
+import { ark } from './arktype';
+
+export const bookDimensionsSchema = ark({
+  width_mm: 'number',
+  height_mm: 'number',
+  thickness_mm: 'number',
+  weight_grams: 'number',
+});
+
+export const acquiredBookDataSchema = ark({
+  title: 'string',
+  authors: ['string', '[]'],
+  isbn: 'string?',
+  publisher: 'string?',
+  blurb: 'string?',
+  dimensions: bookDimensionsSchema.optional,
+}).json;
+
+export type BookDimensions = typeof bookDimensionsSchema.infer;
+export type AcquiredBookData = typeof acquiredBookDataSchema.infer;

--- a/schemas/arktype.ts
+++ b/schemas/arktype.ts
@@ -1,0 +1,1 @@
+export { ark } from 'arktype';

--- a/schemas/codexSchema.ts
+++ b/schemas/codexSchema.ts
@@ -1,0 +1,12 @@
+import { ark } from './arktype';
+
+export const codexRuleSchema = ark({
+  id: 'string',
+  category: "'Core Directive'|'Ethical Constraint'|'Operational Protocol'",
+  title: 'string',
+  content: 'string',
+  ratified: 'string',
+  ratifyingBody: 'string',
+}).json;
+
+export type CodexRule = typeof codexRuleSchema.infer;

--- a/schemas/playbookSchema.ts
+++ b/schemas/playbookSchema.ts
@@ -1,0 +1,16 @@
+import { ark } from './arktype';
+
+export const playbookStepSchema = ark({
+  name: 'string',
+  agentId: 'string',
+  prompt: 'string',
+});
+
+export const playbookSchema = ark({
+  id: 'string',
+  name: 'string',
+  description: 'string',
+  steps: [playbookStepSchema, '[]'],
+}).json;
+
+export type Playbook = typeof playbookSchema.infer;


### PR DESCRIPTION
## Summary
- add `schemas` folder
- add `arktype` helper re-export
- define acquisition schema and types
- define codex and playbook schemas used by the loom service

## Testing
- `npm test --silent --run`

------
https://chatgpt.com/codex/tasks/task_b_68875a001aa48330a3ee1cf74958752b