### PR TITLE
Add .gitignore to exclude common files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+__pycache__/
+*.pyc
+.env
+.env.*
+dist/
+*.log
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add repository-wide `.gitignore` to ignore Node modules, Python caches, environment files, build outputs, logs and OS-specific files

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688739eacfc48330a62e91487c48f675