### PR TITLE
Add FastAPI endpoint and CRUD tests

### DIFF
--- a/backend/tests/test_additional_routes.py
+++ b/backend/tests/test_additional_routes.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_routes_add.db"
+
+from app.main import app
+from app.database import Base, get_db
+
+engine = create_engine(os.environ["DATABASE_URL"], connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"
+
+@pytest.mark.anyio
+async def test_get_tasks_empty():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get("/tasks")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+@pytest.mark.anyio
+async def test_get_task_not_found():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.get("/tasks/9999")
+    assert resp.status_code == 404

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.database import Base
+from app import crud, schemas
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_create_task(db_session):
+    task_in = schemas.TaskCreate(title="Task 1", description="desc", status="pending")
+    created = crud.create_task(db_session, task_in)
+    assert created.id > 0
+    assert created.title == "Task 1"
+
+
+def test_get_task(db_session):
+    task_in = schemas.TaskCreate(title="Another", description="desc", status="pending")
+    created = crud.create_task(db_session, task_in)
+    fetched = crud.get_task(db_session, created.id)
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+def test_get_tasks(db_session):
+    crud.create_task(db_session, schemas.TaskCreate(title="One", description="d", status="pending"))
+    crud.create_task(db_session, schemas.TaskCreate(title="Two", description="d", status="done"))
+    tasks = crud.get_tasks(db_session)
+    titles = {t.title for t in tasks}
+    assert {"One", "Two"}.issubset(titles)
+
+
+def test_get_task_not_found(db_session):
+    assert crud.get_task(db_session, 9999) is None


### PR DESCRIPTION
## Summary
- cover empty and missing task routes
- test CRUD helper functions

## Testing
- `pip install -q -r backend/requirements.lock`
- `pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_b_68897ed27cb48330833a63469fbdf458